### PR TITLE
Export fst annotation

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -26,7 +26,7 @@ jobs:
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-m2
         with:

--- a/org.wso2.carbon.identity.serializer.fst/pom.xml
+++ b/org.wso2.carbon.identity.serializer.fst/pom.xml
@@ -54,7 +54,8 @@
                         <private-package>org.wso2.carbon.identity.serializer.fst.internal</private-package>
                         <Export-Package>
                             !org.wso2.carbon.identity.serializer.fst.internal,
-                            org.wso2.carbon.identity.serializer.fst.*
+                            org.wso2.carbon.identity.serializer.fst.*,
+                            org.nustaq.serialization.annotations
                         </Export-Package>
                         <Import-Package>
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",


### PR DESCRIPTION
## Purpose
FST is not backward compatible when we adding new field to the object class blueprint. To make backward compatible we need Versioning approach, so export annotations from here to cater that.
